### PR TITLE
fix: members controllers

### DIFF
--- a/controllers/memberController.js
+++ b/controllers/memberController.js
@@ -1,78 +1,9 @@
-const User = require('../models/user');
-const { HTTPMonitor, PingMonitor, KeywordMonitor, PortMonitor, Monitor } = require('../models/monitor');
-
-const monitor = {
-  create: async (req, res) => {
-    try {
-      const { type, monitor, user_id } = req.body;
-      let p;
-      switch (type) {
-        case 'HTTPMonitor':
-          p = new HTTPMonitor(monitor);
-          break;
-
-        case 'PingMonitor':
-          p = new PingMonitor(monitor);
-          break;
-
-        case 'KeywordMonitor':
-          p = new KeywordMonitor(monitor);
-          break;
-
-        case 'PortMonitor':
-          p = new PortMonitor(monitor);
-          break;
-
-        default:
-          p = new Monitor(monitor);
-          break;
-      }
-      User.findByIdAndUpdate({ _id: user_id }, { $push: { monitors: p } }).exec((err, success) => {
-        if (err) throw err;
-        res.json(success);
-      });
-    } catch (err) {
-      throw err;
-    }
-  },
-
-  read: async (req, res) => {
-    //reads a monitor or the monitor list, takes an optional monitor id
-    try {
-      const { user_id, monitor_id } = req.body;
-      //if no specific monitor was requested from the user, send them all
-      if (!monitor_id) {
-        User.find({ _id: user_id }).exec((err, success) => {
-          if (err) throw err;
-          res.json(success.monitors);
-        });
-      } else {
-        //otherwise, send the specific monitor
-        User.find({ _id: user_id, monitors: { _id: monitor_id } }).exec((err, success) => {
-          if (err) throw err;
-          res.json(success);
-        });
-      }
-    } catch (err) {
-      throw err;
-    }
-  },
-
-  update: async (req, res) => {
-    try {
-      const { user_id, monitor_id, monitor } = req.body;
-      User.findOneAndUpdate(
-        { _id: user_id, monitors: { _id: monitor_id } },
-        {
-          $set: { 'monitors.$': monitor },
-        },
-      ).exec((err, success) => {
-        if (err) throw err;
-        res.json(success);
-      });
-    } catch (err) {
-      throw err;
-    }
-  },
+const { monitor } = require('./userController');
+monitor.delete = async (req, res) => {
+  try {
+    res.status(400).json({ message: 'Monitor deletion by member not allowed, contact administrator' });
+  } catch (err) {
+    throw err;
+  }
 };
 module.exports = { monitor };

--- a/controllers/memberController.js
+++ b/controllers/memberController.js
@@ -1,9 +1,15 @@
 const { monitor } = require('./userController');
-monitor.delete = async (req, res) => {
-  try {
-    res.status(400).json({ message: 'Monitor deletion by member not allowed, contact administrator' });
-  } catch (err) {
-    throw err;
-  }
+
+const memberMonitor = {
+  create: monitor.create,
+  read: monitor.read,
+  update: monitor.update,
+  delete: async (req, res) => {
+    try {
+      res.status(400).json({ message: 'Monitor deletion by member not allowed, contact administrator' });
+    } catch (err) {
+      throw err;
+    }
+  },
 };
-module.exports = { monitor };
+module.exports = { memberMonitor };

--- a/docs/api.html
+++ b/docs/api.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Zappnode API</title>
+		<style>
+			h2 {
+				margin: 0px;
+			}
+			body {
+				margin: 0px;
+				background-color: #f3f3f3;
+			}
+			section {
+				padding: 10px;
+			}
+			ul {
+			}
+			li {
+			}
+			.title-container {
+				background-color: #03010b;
+				display: flex;
+				padding: 10px;
+			}
+			.title-container h1 {
+				color: white;
+			}
+			.section-title {
+				background-color: #2ecc71;
+				color: #f3f3f3;
+				display: flex;
+				flex-direction: column;
+				padding: 10px;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="title-container">
+			<h1>Zappnode API</h1>
+		</div>
+		<section>
+			<div class="section-title">
+				<h2>Users</h2>
+				<p>This section deals with the endpoints of /api/users</p>
+			</div>
+			<h3>/api/users</h3>
+			<p>These endpoints operate on user information</p>
+			<ul>
+				<li>
+					<p>POST:/api/users/</p>
+					<p>
+						Create a new user. Expects a user object. Returns a
+						message indicating success or error
+					</p>
+				</li>
+				<li>
+					<p>GET:/api/users/</p>
+					<p>
+						Get a user or users. Returns a specific user by id
+						if user_id is specified in the request body.
+						Otherwise returns all users.
+					</p>
+				</li>
+				<li>
+					<p>PATCH:/api/users/</p>
+					<p>
+						Update a user. Expects data fields of the user
+						object to update. Returns a status message
+						indicating success or failure. This route updates
+						the logged in user by their id, thus it REQUIRES a
+						logged in user and will update ONLY that user. The
+						user's id is submitted automatically as part of
+						their session and does not need to be sent with the
+						body
+					</p>
+				</li>
+				<li>
+					<p>DELETE:/api/users/</p>
+					<p>
+						Delete a user. This endpoint REQUIRES a logged in
+						user, and will delete only that user. The user id is
+						submitted automattically as part of their session
+						and does not need to be sent with the body.
+						Redirects the user to logout on success, otherwise
+						throws error
+					</p>
+				</li>
+			</ul>
+			<h3>/api/users/monitor</h3>
+			<p>
+				These endpoints operate specifically on monitors within the user's
+				monitors array
+			</p>
+			<ul>
+				<li>
+					<p>POST:/api/users/monitor</p>
+					<p>
+						Create a new monitor. Expects a monitor type, a
+						monitor object, and a user_id. Valid monitor types
+						are: 'HTTPMonitor', 'PingMonitor', 'KeywordMonitor',
+						'PortMonitor'. On success, returns the user. On
+						failure, throws error.
+					</p>
+				</li>
+				<li>
+					<p>GET:/api/users/monitor</p>
+					<p>
+						Read an existing monitor(s). Expects a user_id and
+						an optional monitor_id. Returns the specific monitor
+						requested if monitor_id is present, otherwise
+						returns the user's whole monitor array. On success
+						returns the monitor object or array, on failure
+						throws error.
+					</p>
+				</li>
+				<li>
+					<p>PUT:/api/users/monitor</p>
+					<p>
+						Update an existing monitor. Expects a user_id and a
+						monitor object. On success, returns the updated
+						monitor, on failure throws error.
+					</p>
+				</li>
+				<li>
+					<p>DELETE:/api/users/monitor</p>
+					<p>
+						Delete a monitor. Expects a user_id and a
+						monitor_id. On success returns the user that
+						contained the deleted array. On failure throws error
+					</p>
+				</li>
+			</ul>
+			<h3>/api/users/member</h3>
+			<p>
+				These endpoints operate specifically on the members in a user's
+				member array.
+			</p>
+			<ul>
+				<li>
+					<p>POST:/api/users/member</p>
+					<p>
+						Create a new member on the user. Expects a user_id
+						and a member_id. On success returns the user, on
+						failure throws an error.
+					</p>
+				</li>
+				<li>
+					<p>GET: /api/users/member</p>
+					<p>
+						Read an existing member. Expects a member_id. On
+						success returns that member's user object. On
+						failure throws error.
+					</p>
+				</li>
+				<li>
+					<p>PUT: /api/users/member</p>
+					<p>Not Yet Implemented</p>
+				</li>
+				<li>
+					<p>DELETE: /api/users/member</p>
+					<p>
+						Delete a member from the user. Expects a user_id and
+						a member_id. On success returns the user, on failure
+						throws error
+					</p>
+				</li>
+			</ul>
+		</section>
+		<section>
+			<div class="section-title">
+				<h2>Members</h2>
+				<p>This section deals with the endpoints of /api/members</p>
+			</div>
+			<h3>/api/members/monitor</h3>
+			<p>
+				These endpoints operate on a monitor in a member's parent's monitor
+				array
+			</p>
+			<ul>
+				<li>
+					<p>POST:/api/members/monitor</p>
+					<p>
+						Create a new monitor on the member parent. Expects a
+						monitor type, a monitor object, and a user_id. Valid
+						monitor types are: 'HTTPMonitor', 'PingMonitor',
+						'KeywordMonitor', 'PortMonitor'. On success, returns
+						the user. On failure, throws error. This route
+						REQUIRES a logged in user.
+					</p>
+				</li>
+				<li>
+					<p>GET: /api/members/monitor</p>
+					<p>
+						Read an existing monitor(s). Expects a user_id and
+						an optional monitor_id. Returns the specific monitor
+						requested if monitor_id is present, otherwise
+						returns the user's whole monitor array. On success
+						returns the monitor object or array, on failure
+						throws error. This route REQUIRES a logged in user.
+					</p>
+				</li>
+				<li>
+					<p>PUT:/api/members/monitor</p>
+					<p>
+						Update an existing monitor. Expects a user_id and a
+						monitor object. On success, returns the updated
+						monitor, on failure throws error. This route
+						REQUIRES a logged in user.
+					</p>
+				</li>
+			</ul>
+		</section>
+		<section>
+			<div class="section-title">
+				<h2>Auth</h2>
+				<p>This section deals with the endpoints of /api/auth</p>
+			</div>
+			<p>This section is pending</p>
+		</section>
+		<section>
+			<div class="section-title">
+				<h2>Alerts</h2>
+				<p>This section deals with the endpoints of /api/alerts</p>
+			</div>
+			<p>This section is pending</p>
+		</section>
+	</body>
+</html>

--- a/routes/api/members.js
+++ b/routes/api/members.js
@@ -6,7 +6,7 @@ const authController = require('../../controllers/authController.js');
 //monitors-- user for operations related to member parent subscriptions------
 
 //delete a monitor from a parent user's subscription array
-router.post('/monitor', authController.isLoggedIn, memberController.monitor.create); //placeholder
-router.get('/monitor', authController.isLoggedIn, memberController.monitor.read); //placeholder
-router.put('/monitor', authController.isLoggedIn, memberController.monitor.update); //placeholder
+router.post('/monitor', authController.isLoggedIn, memberController.memberMonitor.create); //placeholder
+router.get('/monitor', authController.isLoggedIn, memberController.memberMonitor.read); //placeholder
+router.put('/monitor', authController.isLoggedIn, memberController.memberMonitor.update); //placeholder
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -33,7 +33,9 @@ app.use('/api/users', require('./routes/api/users'));
 app.use('/api/auth', require('./routes/api/auth'));
 app.use('/api/alerts', require('./routes/api/alerts'));
 app.use('/api/members', require('./routes/api/members'));
-
+app.use('/api/info', (req, res) => {
+  res.sendFile('docs/api.html', { root: __dirname });
+});
 const PORT = process.env.PORT || 5000;
 
 app.listen(PORT, () => console.log(`Server started on port ${PORT}`));


### PR DESCRIPTION
this replaces the /members/monitors controllers with the ones defined in /uesers/monitor. They're the same operations, so they should just pull from the same source, rather than duplicate it. Additionally, the monitor/delete is replaced with an error message, since we're not allowing that functionality for members.